### PR TITLE
upgrade Cheshire to version 5.10.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.2.0"
   :pedantic? :abort
-  :dependencies [[cheshire "5.8.1"]]
+  :dependencies [[cheshire "5.10.0"]]
   :global-vars {*assert* true
                 *warn-on-reflection* true
                 *unchecked-math* :warn-on-boxed}


### PR DESCRIPTION
Cheshire 5.10.0 upgrades jackson to 2.10.2 which fixes some major vulnerabilities